### PR TITLE
Avoid 'window is not defined' error

### DIFF
--- a/packages/sysweb3-core/src/cross-platform/clients/fetch.http.ts
+++ b/packages/sysweb3-core/src/cross-platform/clients/fetch.http.ts
@@ -1,4 +1,6 @@
-const defaultFetch = window.fetch.bind(window) ? window.fetch.bind(window) : undefined;
+declare let window: any;
+const defaultFetch =
+  typeof window !== 'undefined' ? window.fetch.bind(window) : undefined;
 
 export const FetchRestService = (httpClient: any = defaultFetch) => {
   const invoke = (options: RestApiOptionsRequest) => {

--- a/packages/sysweb3-core/src/cross-platform/clients/state-storage-db.ts
+++ b/packages/sysweb3-core/src/cross-platform/clients/state-storage-db.ts
@@ -1,6 +1,8 @@
 import { IKeyValueDb } from './../i-key-value-db';
 
-const defaultStorage = window.localStorage ? window.localStorage : undefined;
+declare let window: any;
+const defaultStorage =
+  typeof window !== 'undefined' ? window.localStorage : undefined;
 
 export const StateStorageDb = (
   storageClient: IStateStorageClient | undefined = defaultStorage


### PR DESCRIPTION
Both `defaultStorage` and `defaultFetch` were throwing the 'window is not defined error' when running from node env