### PR TITLE
Standardize type definitions and paths

### DIFF
--- a/packages/sysweb3-core/package.json
+++ b/packages/sysweb3-core/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.16",
   "description": "",
   "main": "cjs/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Pollum-io/sysweb3.git"

--- a/packages/sysweb3-core/tsconfig.cjs.json
+++ b/packages/sysweb3-core/tsconfig.cjs.json
@@ -7,6 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },
-
   "include": ["src"]
 }

--- a/packages/sysweb3-core/tsconfig.json
+++ b/packages/sysweb3-core/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": "src",
     "baseUrl": "src",
     "outDir": "dist/esm",
+    "declarationDir": "dist/types",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "noEmit": false

--- a/packages/sysweb3-keyring/package.json
+++ b/packages/sysweb3-keyring/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.283",
   "description": "",
   "main": "cjs/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Pollum-io/sysweb3.git"

--- a/packages/sysweb3-keyring/tsconfig.cjs.json
+++ b/packages/sysweb3-keyring/tsconfig.cjs.json
@@ -2,11 +2,11 @@
   "extends": "../../tsconfig-package-cjs.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "declarationDir": "dist/types",
     "lib": ["esnext", "dom"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-
   "include": ["src"]
 }

--- a/packages/sysweb3-keyring/tsconfig.json
+++ b/packages/sysweb3-keyring/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": "src",
     "baseUrl": "src",
     "outDir": "dist/esm",
+    "declarationDir": "dist/types",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true
   },

--- a/packages/sysweb3-network/package.json
+++ b/packages/sysweb3-network/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.37",
   "description": "A network management tool for multi-chain accounts.",
   "main": "cjs/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Pollum-io/sysweb3.git"

--- a/packages/sysweb3-network/tsconfig.cjs.json
+++ b/packages/sysweb3-network/tsconfig.cjs.json
@@ -2,10 +2,10 @@
   "extends": "../../tsconfig-package-cjs.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "declarationDir": "dist/types",
     "lib": ["esnext", "dom"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },
-
   "include": ["src"]
 }

--- a/packages/sysweb3-utils/package.json
+++ b/packages/sysweb3-utils/package.json
@@ -3,13 +3,13 @@
   "version": "1.1.133",
   "description": "A helper for multi-chain accounts.",
   "main": "cjs/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Pollum-io/sysweb3.git"
   },
   "author": "Pali Wallet",
   "license": "MIT",
-  "types": "./dist/esm/index.d.ts",
   "private": false,
   "scripts": {
     "prebuild": "rimraf dist/",

--- a/packages/sysweb3-utils/tsconfig.cjs.json
+++ b/packages/sysweb3-utils/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig-package-cjs.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "declarationDir": "dist/types",
     "lib": ["esnext", "dom"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/sysweb3-utils/tsconfig.json
+++ b/packages/sysweb3-utils/tsconfig.json
@@ -4,9 +4,9 @@
     "rootDir": "src",
     "baseUrl": "src",
     "outDir": "dist/esm",
+    "declarationDir": "dist/types",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "declarationDir": "dist",
     "noImplicitReturns": false
   },
   "include": ["src"]


### PR DESCRIPTION
Every package had a different config for type declarations and core package config was broken.
This update set all packages to use dist/types as default path for declarations.
Updates both package.json and tsconfigs
