### PR TITLE
Refactor getFiatValueByToken

### DIFF
--- a/packages/sysweb3-utils/package.json
+++ b/packages/sysweb3-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollum-io/sysweb3-utils",
-  "version": "1.1.147",
+  "version": "1.1.148",
   "description": "A helper for multi-chain accounts.",
   "main": "cjs/index.js",
   "types": "types/index.d.ts",

--- a/packages/sysweb3-utils/src/tokens.ts
+++ b/packages/sysweb3-utils/src/tokens.ts
@@ -92,16 +92,16 @@ export const getToken = async (id: string): Promise<ICoingeckoToken> => {
 export const getFiatValueByToken = async (
   token: string,
   fiat: string
-): Promise<{
-  price: number;
-  priceChange: number;
-}> => {
-  const { marketData } = await getToken(token);
+): Promise<number> => {
+  try {
+    const response = await axios.get(
+      `${COINGECKO_API}/simple/price?ids=${token}&vs_currencies=${fiat}`
+    );
 
-  return {
-    price: marketData.currentPrice[fiat],
-    priceChange: marketData.priceChange24H,
-  };
+    return response.data[fiat];
+  } catch (error) {
+    throw new Error(`Unable to retrieve ${token} price as ${fiat} `);
+  }
 };
 
 /**

--- a/packages/sysweb3-utils/src/tokens.ts
+++ b/packages/sysweb3-utils/src/tokens.ts
@@ -98,7 +98,7 @@ export const getFiatValueByToken = async (
       `${COINGECKO_API}/simple/price?ids=${token}&vs_currencies=${fiat}`
     );
 
-    return response.data[fiat];
+    return response.data[token][fiat];
   } catch (error) {
     throw new Error(`Unable to retrieve ${token} price as ${fiat} `);
   }

--- a/packages/sysweb3-utils/test/tokens.spec.ts
+++ b/packages/sysweb3-utils/test/tokens.spec.ts
@@ -24,9 +24,7 @@ describe('web3-NFT tests', () => {
   it('should retrieve a token price as fiat', async () => {
     const result = await getFiatValueByToken('syscoin', 'usd');
 
-    expect(typeof result.price).toBe('number');
-    expect(result.price).toBeGreaterThan(0);
-
-    expect(typeof result.priceChange).toBe('number');
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
There is a specific endpoint for this function. No need to retrieve the complete token information